### PR TITLE
Revert "Bump golang from 1.17.8 to 1.18.0 in /docker"

### DIFF
--- a/docker/shfmt.dockerfile
+++ b/docker/shfmt.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.0 AS gobuilder
+FROM golang:1.17.8 AS gobuilder
 
 ENV USER=formatter
 ENV UID=10001


### PR DESCRIPTION
Reverts wayfair-incubator/cloud-functions-buildkite-plugin#139